### PR TITLE
Change from a paper-toolbar to an iron-flex-layout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.0.0",
-    "paper-toolbar": "PolymerElements/paper-toolbar#^1.0.0",
+    "paper-toolbar": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "polymer-cookie": "Scarygami/polymer-cookie#^1.0.0"
   },

--- a/cookie-consent.html
+++ b/cookie-consent.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-toolbar/paper-toolbar.html">
+<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../polymer-cookie/polymer-cookie.html">
@@ -55,7 +55,8 @@ cookie-consent {
 -->
 <dom-module id="cookie-consent">
   <style>
-    paper-toolbar {
+    #container {
+      padding: 18px;
       font-size: 1em;
       background: var(--cookie-consent-background);
       color: var(--cookie-consent-color);
@@ -70,12 +71,12 @@ cookie-consent {
   <template>
     <polymer-cookie id="cookie" name="{{cookieName}}"></polymer-cookie>
 
-    <paper-toolbar hidden$="[[_isToolbarHidden(consent, dismissed)]]">
+    <div id="container" class="layout horizontal center" hidden$="[[_isToolbarHidden(consent, dismissed)]]">
       <span id="info" class="flex"><content></content></span>
       <a href="{{policy}}" hidden$="[[!_hasPolicy(policy)]]"><paper-icon-button icon="info-outline"></paper-icon-button></a>
       <paper-icon-button icon="check" on-click="_giveConsent"></paper-icon-button>
       <paper-icon-button icon="close" on-click="_dismiss"></paper-icon-button>
-    </paper-toolbar>
+    </div>
   </template>
 </dom-module>
 


### PR DESCRIPTION
The paper-toolbar component crops long texts correctly on mobile versions, so I changed it to a div that can grow vertically with the amount of text.

Original version:
![cookie-consent](https://cloud.githubusercontent.com/assets/12693582/7911718/a04dacdc-0858-11e5-8509-a2c785ecc515.png)

Changed version:
![cookie-consent-2](https://cloud.githubusercontent.com/assets/12693582/7911786/5864229c-0859-11e5-9d02-64cc2c7132c6.png)
